### PR TITLE
Multiple format changes at once

### DIFF
--- a/pyEventLogger/pyEventLogger.py
+++ b/pyEventLogger/pyEventLogger.py
@@ -158,13 +158,16 @@ class pyLogger:
     def format_log(self, log_type, format_string):
         """
         Format the Log
-        :param log_type: The log type
+        :param log_type: The log type. Input multiple log types in a list to change at once!
         :param format_string: The format string
         """
-        if log_type in _logging_levels:
-            self.log_format[log_type]['Format'] = self._parse_format_log_text(format_string, False)
-        else:
-            raise Exceptions.LogTypeException(f"Invalid log type given. Use one from {_logging_levels}")
+        if not type(log_type) is list:
+            log_type =  [log_type]
+        for item in log_type:
+            if log_type in _logging_levels:
+                self.log_format[log_type]['Format'] = self._parse_format_log_text(format_string, False)
+            else:
+                raise Exceptions.LogTypeException(f"Invalid log type given. Use one from {_logging_levels}")
 
     def format_log_color(self, log_type, format_string):
         """


### PR DESCRIPTION
Added a for loop and also made it such that you can input both a list and a string into the `log_type` param to change multiple formats at once.

Also you can edit to change some stuff

**not tested**

### use case:
To change 2 formats:
```py
logger.format_log(log_type='DEBUG', format_string=debug_format_string)
logger.format_log(log_type='ERROR', format_string=debug_format_string)
```
Now:
```py
logger.format_log(log_type=['DEBUG', 'ERROR'], format_string=debug_format_string)
```
changing 1 at a time should work as it used to because of line 164